### PR TITLE
Parallelize rollout weight reloads

### DIFF
--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -24,6 +24,8 @@ commonly changed for experiments and cluster deployments.
 | `max_head_offpolicyness` | Maximum accepted policy-version lag |
 | `recompute_logprobs` | Recompute log probabilities with the current model |
 | `sync_interval` | Training steps between weight sync attempts |
+| `rollout_weight_reload_method` | Use `restart` for process replacement or `inplace` to refresh resident vLLM workers |
+| `rollout_weight_reload_strategy` | Reload rollout instances concurrently with `parallel` (default), or use the node-serialized `serial` fallback |
 
 ## Megatron-Core Options
 
@@ -59,3 +61,18 @@ commonly changed for experiments and cluster deployments.
 
 See the [cluster manual](manual.md) for recommended combinations and launch
 examples.
+
+## Rollout Weight Reloads
+
+When `rollout_weight_sync_mode` is `restart`, the trainer publishes one reload
+request for the complete rollout instance set and waits for the whole ACK batch.
+`rollout_weight_reload_method` controls how each vLLM instance applies the
+checkpoint: `restart` replaces the server process, while `inplace` calls the
+guarded reload endpoint and keeps the server resident. The default
+`rollout_weight_reload_strategy: parallel` applies the selected method to all
+instances concurrently. Use `serial` only as an operational fallback on nodes
+that cannot tolerate concurrent model loads.
+
+Each ACK records method, strategy, lock wait, process stop, model load, and total
+reload time. The trainer validates every ACK and reports the slowest instance
+for each refresh.

--- a/scripts/restartable_vllm_server.py
+++ b/scripts/restartable_vllm_server.py
@@ -150,7 +150,9 @@ def main() -> int:
                     if reload_method not in {"restart", "inplace"}:
                         raise ValueError(f"unsupported reload method: {reload_method}")
                     if reload_strategy not in {"parallel", "serial"}:
-                        raise ValueError(f"unsupported reload strategy: {reload_strategy}")
+                        raise ValueError(
+                            f"unsupported reload strategy: {reload_strategy}"
+                        )
                 except (OSError, ValueError, KeyError, json.JSONDecodeError):
                     time.sleep(max(0.05, args.poll_interval))
                     continue

--- a/scripts/rollout_weight_reload_smoke.py
+++ b/scripts/rollout_weight_reload_smoke.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""GPU smoke test for parallel rollout weight reloads."""
+
+from __future__ import annotations
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+
+def _child(port: int, startup_delay: float) -> int:
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available in the Slurm allocation")
+    value = (torch.ones(1024, device="cuda") * 2).sum().item()
+    torch.cuda.synchronize()
+    if value != 2048:
+        raise RuntimeError(f"unexpected CUDA result: {value}")
+    time.sleep(startup_delay)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"ok")
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def do_POST(self):
+            if self.path != "/reload_weights":
+                self.send_response(404)
+                self.end_headers()
+                return
+            content_length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+            checkpoint_path = Path(payload["checkpoint_path"])
+            if not checkpoint_path.is_dir():
+                self.send_response(400)
+                self.end_headers()
+                return
+            time.sleep(startup_delay)
+            response = json.dumps(
+                {
+                    "checkpoint_path": str(checkpoint_path),
+                    "workers": [{"rank": 0}],
+                }
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+
+        def log_message(self, format, *args):
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    server.serve_forever()
+    return 0
+
+
+def _wait_for_paths(paths: list[Path], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if all(path.exists() for path in paths):
+            return
+        time.sleep(0.1)
+    missing = [str(path) for path in paths if not path.exists()]
+    raise TimeoutError(f"timed out waiting for reload ACKs: {missing}")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(ports: tuple[int, ...], timeout: float) -> None:
+    pending = set(ports)
+    deadline = time.monotonic() + timeout
+    while pending and time.monotonic() < deadline:
+        for port in list(pending):
+            try:
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/health",
+                    timeout=1,
+                ) as response:
+                    if response.status == 200:
+                        pending.remove(port)
+            except Exception:
+                pass
+        if pending:
+            time.sleep(0.1)
+    if pending:
+        raise TimeoutError(
+            f"initial services did not become healthy: {sorted(pending)}"
+        )
+
+
+def _stop(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+
+
+def _run_reload(
+    *,
+    control_dir: Path,
+    checkpoint: Path,
+    instance_ids: tuple[str, ...],
+    version: int,
+    method: str,
+    timeout: float,
+) -> dict:
+    request = {
+        "version": version,
+        "checkpoint_path": str(checkpoint),
+        "reload_method": method,
+        "reload_strategy": "parallel",
+        "instance_ids": list(instance_ids),
+        "created_at": time.time(),
+    }
+    request_tmp = control_dir / "reload_request.json.tmp"
+    request_tmp.write_text(json.dumps(request), encoding="utf-8")
+    started_at = time.monotonic()
+    request_tmp.replace(control_dir / "reload_request.json")
+    ack_paths = [
+        control_dir / f"ack_{instance_id}_{version}.json"
+        for instance_id in instance_ids
+    ]
+    _wait_for_paths(ack_paths, timeout)
+    elapsed = time.monotonic() - started_at
+    acks = [json.loads(path.read_text(encoding="utf-8")) for path in ack_paths]
+    if any(ack["reload_method"] != method for ack in acks):
+        raise AssertionError(f"unexpected reload method in ACK batch: {acks}")
+    if any(ack["reload_strategy"] != "parallel" for ack in acks):
+        raise AssertionError(f"unexpected reload strategy in ACK batch: {acks}")
+    started = [float(ack["reload_started_at"]) for ack in acks]
+    ready = [float(ack["ready_at"]) for ack in acks]
+    start_skew = max(started) - min(started)
+    reload_span = max(ready) - min(started)
+    serial_work = sum(float(ack["total_seconds"]) for ack in acks)
+    overlap_seconds = min(ready) - max(started)
+    if overlap_seconds <= 0:
+        raise AssertionError(
+            f"reload intervals did not overlap: method={method}, "
+            f"span={reload_span:.2f}s, serial_work={serial_work:.2f}s"
+        )
+    return {
+        "method": method,
+        "batch_elapsed_s": round(elapsed, 3),
+        "reload_span_s": round(reload_span, 3),
+        "serial_work_s": round(serial_work, 3),
+        "reload_start_skew_s": round(start_skew, 3),
+        "reload_overlap_s": round(overlap_seconds, 3),
+        "slowest_instance_s": round(
+            max(float(ack["total_seconds"]) for ack in acks),
+            3,
+        ),
+    }
+
+
+def _orchestrate(startup_delay: float, timeout: float) -> int:
+    project_dir = Path(__file__).resolve().parents[1]
+    reloader = project_dir / "scripts" / "restartable_vllm_server.py"
+    with tempfile.TemporaryDirectory(prefix="rollout-reload-smoke-") as tmp:
+        root = Path(tmp)
+        control_dir = root / "control"
+        initial_model = root / "initial_model"
+        inplace_checkpoint = root / "checkpoint_v1"
+        restart_checkpoint = root / "checkpoint_v2"
+        control_dir.mkdir()
+        initial_model.mkdir()
+        inplace_checkpoint.mkdir()
+        restart_checkpoint.mkdir()
+        ports = (_free_port(), _free_port())
+        instance_ids = ("smoke_0", "smoke_1")
+        processes = []
+        try:
+            for instance_id, port in zip(instance_ids, ports):
+                command = [
+                    sys.executable,
+                    str(reloader),
+                    "--instance-id",
+                    instance_id,
+                    "--control-dir",
+                    str(control_dir),
+                    "--health-url",
+                    f"http://127.0.0.1:{port}/health",
+                    "--initial-model",
+                    str(initial_model),
+                    "--ready-timeout",
+                    str(timeout),
+                    "--poll-interval",
+                    "0.05",
+                    "--",
+                    sys.executable,
+                    str(Path(__file__).resolve()),
+                    "--child",
+                    "--port",
+                    str(port),
+                    "--startup-delay",
+                    str(startup_delay),
+                    "--model-path",
+                    "__MODEL_PATH__",
+                ]
+                processes.append(subprocess.Popen(command, start_new_session=True))
+
+            _wait_for_health(ports, timeout)
+            if any(process.poll() is not None for process in processes):
+                raise RuntimeError("a reload supervisor exited during initial startup")
+
+            inplace_result = _run_reload(
+                control_dir=control_dir,
+                checkpoint=inplace_checkpoint,
+                instance_ids=instance_ids,
+                version=1,
+                method="inplace",
+                timeout=timeout,
+            )
+            restart_result = _run_reload(
+                control_dir=control_dir,
+                checkpoint=restart_checkpoint,
+                instance_ids=instance_ids,
+                version=2,
+                method="restart",
+                timeout=timeout,
+            )
+            print(
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "torch_cuda_smoke": True,
+                        "instances": len(instance_ids),
+                        "startup_delay_s": startup_delay,
+                        "reloads": [inplace_result, restart_result],
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        finally:
+            for process in processes:
+                _stop(process)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--child", action="store_true")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--startup-delay", type=float, default=3.0)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--model-path", default="")
+    args = parser.parse_args()
+    if args.child:
+        del args.model_path
+        return _child(args.port, args.startup_delay)
+    return _orchestrate(args.startup_delay, args.timeout)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/submit_r2e_gym_cmlfq_24gpu_qwen3_30b_a3b.slurm
+++ b/scripts/submit_r2e_gym_cmlfq_24gpu_qwen3_30b_a3b.slurm
@@ -149,6 +149,8 @@ GRP_VLLM_STOP_COMMAND_TEMPLATE="${GRP_VLLM_STOP_COMMAND_TEMPLATE:-}"
 ROLLOUT_WEIGHT_SYNC_MODE="${ROLLOUT_WEIGHT_SYNC_MODE:-restart}"
 REQUIRE_ROLLOUT_WEIGHT_SYNC="${REQUIRE_ROLLOUT_WEIGHT_SYNC:-1}"
 ROLLOUT_WEIGHT_SYNC_EXPORT_ONLY="${ROLLOUT_WEIGHT_SYNC_EXPORT_ONLY:-1}"
+ROLLOUT_WEIGHT_RELOAD_METHOD="${ROLLOUT_WEIGHT_RELOAD_METHOD:-restart}"
+ROLLOUT_WEIGHT_RELOAD_STRATEGY="${ROLLOUT_WEIGHT_RELOAD_STRATEGY:-parallel}"
 MEGATRON_STREAMING_EXPORT="${MEGATRON_STREAMING_EXPORT:-1}"
 PREFERRED_TRAIN_NODE="${PREFERRED_TRAIN_NODE:-gn026}"
 AVOID_TRAIN_NODE="${AVOID_TRAIN_NODE:-gn019}"
@@ -176,7 +178,7 @@ if [ "$VLLM_DISABLE_CUSTOM_ALL_REDUCE" = "1" ]; then
     VLLM_CUSTOM_ALL_REDUCE_FLAG="--disable-custom-all-reduce"
 fi
 if [ "$GRP_MANAGE_ROLLOUT_PROCESSES" = "1" ] && [ -z "$GRP_VLLM_LAUNCH_COMMAND_TEMPLATE" ]; then
-    GRP_VLLM_LAUNCH_COMMAND_TEMPLATE="srun --exclusive --nodes=1 --ntasks=1 --nodelist={host} --gpus={tp} --cpus-per-task=16 bash -lc \"source '$VENV_PATH' && export TOKENIZERS_PARALLELISM=false && export PLANNED_CUDA_VISIBLE_DEVICES={gpus} && if [ -z \\\"\\\${{CUDA_VISIBLE_DEVICES:-}}\\\" ]; then export CUDA_VISIBLE_DEVICES=\\\"\\\$PLANNED_CUDA_VISIBLE_DEVICES\\\"; fi && echo \\\"CUDA_VISIBLE_DEVICES=\\\${{CUDA_VISIBLE_DEVICES}} planned=\\\${{PLANNED_CUDA_VISIBLE_DEVICES}}\\\" && export MASTER_ADDR=127.0.0.1 && export MASTER_PORT=\\\$((20000 + {port})) && export NCCL_P2P_DISABLE='$VLLM_NCCL_P2P_DISABLE' && export NCCL_IB_DISABLE='$VLLM_NCCL_IB_DISABLE' && export CUDA_LAUNCH_BLOCKING='$VLLM_CUDA_LAUNCH_BLOCKING' && {python} '$PROJECT_DIR/scripts/restartable_vllm_server.py' --instance-id {instance_id} --control-dir {control_dir} --health-url {local_health_url} --initial-model {initial_model} --ready-timeout '$MAX_WAIT' -- python3 -m vllm.entrypoints.openai.api_server --model __MODEL_PATH__ --served-model-name {model_path} --host 0.0.0.0 --port {port} --tensor-parallel-size {tp} --max-model-len {max_model_len} --dtype bfloat16 --gpu-memory-utilization {gpu_memory_utilization} --trust-remote-code --enforce-eager $VLLM_CUSTOM_ALL_REDUCE_FLAG\""
+    GRP_VLLM_LAUNCH_COMMAND_TEMPLATE="srun --exclusive --nodes=1 --ntasks=1 --nodelist={host} --gpus={tp} --cpus-per-task=16 bash -lc \"source '$VENV_PATH' && export TOKENIZERS_PARALLELISM=false && export PLANNED_CUDA_VISIBLE_DEVICES={gpus} && if [ -z \\\"\\\${{CUDA_VISIBLE_DEVICES:-}}\\\" ]; then export CUDA_VISIBLE_DEVICES=\\\"\\\$PLANNED_CUDA_VISIBLE_DEVICES\\\"; fi && echo \\\"CUDA_VISIBLE_DEVICES=\\\${{CUDA_VISIBLE_DEVICES}} planned=\\\${{PLANNED_CUDA_VISIBLE_DEVICES}}\\\" && export MASTER_ADDR=127.0.0.1 && export MASTER_PORT=\\\$((20000 + {port})) && export NCCL_P2P_DISABLE='$VLLM_NCCL_P2P_DISABLE' && export NCCL_IB_DISABLE='$VLLM_NCCL_IB_DISABLE' && export CUDA_LAUNCH_BLOCKING='$VLLM_CUDA_LAUNCH_BLOCKING' && {python} '$PROJECT_DIR/scripts/restartable_vllm_server.py' --instance-id {instance_id} --control-dir {control_dir} --health-url {local_health_url} --initial-model {initial_model} --ready-timeout '$MAX_WAIT' --reload-method '$ROLLOUT_WEIGHT_RELOAD_METHOD' --reload-strategy '$ROLLOUT_WEIGHT_RELOAD_STRATEGY' -- python3 '$PROJECT_DIR/scripts/vllm_hot_reload_api_server.py' --worker-extension-cls RL_Framework.vllm_hot_reload.InplaceReloadWorkerExtension --model __MODEL_PATH__ --served-model-name {model_path} --host 0.0.0.0 --port {port} --tensor-parallel-size {tp} --max-model-len {max_model_len} --dtype bfloat16 --gpu-memory-utilization {gpu_memory_utilization} --trust-remote-code --enforce-eager $VLLM_CUSTOM_ALL_REDUCE_FLAG\""
 fi
 if [ "$GRP_MANAGE_ROLLOUT_PROCESSES" = "1" ] && [ -z "$GRP_VLLM_STOP_COMMAND_TEMPLATE" ]; then
     GRP_VLLM_STOP_COMMAND_TEMPLATE="srun --overlap --nodes=1 --ntasks=1 --nodelist={host} bash -lc \"pkill -TERM -f 'restartable_vllm_server.py.*--instance-id {instance_id}' || pkill -TERM -f 'vllm.entrypoints.openai.api_server.*--port {port}' || true\""
@@ -236,6 +238,8 @@ export GRP_VLLM_STOP_COMMAND_TEMPLATE
 export ROLLOUT_WEIGHT_SYNC_MODE
 export REQUIRE_ROLLOUT_WEIGHT_SYNC
 export ROLLOUT_WEIGHT_SYNC_EXPORT_ONLY
+export ROLLOUT_WEIGHT_RELOAD_METHOD
+export ROLLOUT_WEIGHT_RELOAD_STRATEGY
 export MEGATRON_STREAMING_EXPORT
 mkdir -p "$JOB_LOG_DIR"
 mkdir -p "$ROLLOUT_SYNC_DIR"
@@ -559,6 +563,8 @@ seed = {
     "rollout_weight_sync_control_dir": str(project / "logs" / "r2e_gym_cmlfq_24gpu" / f"job_{os.environ['JOB_ID']}" / "rollout_weight_sync"),
     "rollout_weight_sync_timeout_s": int(os.environ["MAX_WAIT"]),
     "rollout_weight_sync_export_only": os.environ.get("ROLLOUT_WEIGHT_SYNC_EXPORT_ONLY", "1") == "1",
+    "rollout_weight_reload_method": os.environ.get("ROLLOUT_WEIGHT_RELOAD_METHOD", "restart"),
+    "rollout_weight_reload_strategy": os.environ.get("ROLLOUT_WEIGHT_RELOAD_STRATEGY", "parallel"),
     "require_rollout_weight_sync": os.environ.get("REQUIRE_ROLLOUT_WEIGHT_SYNC", "1") == "1",
     "log_dir": str(project / "logs" / "r2e_gym_cmlfq_24gpu"),
     "wandb_run_name": f"{os.environ['EXPERIMENT_TAG']}-{os.environ['JOB_ID']}",
@@ -1036,7 +1042,10 @@ start_vllm() {
                 --health-url 'http://127.0.0.1:$port/health' \
                 --initial-model '$MODEL_PATH' \
                 --ready-timeout '$MAX_WAIT' \
-                -- python3 -m vllm.entrypoints.openai.api_server \
+                --reload-method '$ROLLOUT_WEIGHT_RELOAD_METHOD' \
+                --reload-strategy '$ROLLOUT_WEIGHT_RELOAD_STRATEGY' \
+                -- python3 '$PROJECT_DIR/scripts/vllm_hot_reload_api_server.py' \
+                --worker-extension-cls RL_Framework.vllm_hot_reload.InplaceReloadWorkerExtension \
                 --model '__MODEL_PATH__' \
                 --served-model-name '$MODEL_PATH' \
                 --host 0.0.0.0 \

--- a/scripts/submit_rollout_weight_reload_smoke.slurm
+++ b/scripts/submit_rollout_weight_reload_smoke.slurm
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#SBATCH -J rollout_reload_smoke
+#SBATCH -o logs/rollout_reload_smoke_%j.out
+#SBATCH -e logs/rollout_reload_smoke_%j.err
+#SBATCH -p gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus=1
+#SBATCH --cpus-per-task=4
+#SBATCH --time=00:10:00
+
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+VENV_PATH="${VENV_PATH:-${HOME}/rl_framework_env/bin/activate}"
+STARTUP_DELAY="${STARTUP_DELAY:-3}"
+
+source "$VENV_PATH"
+cd "$PROJECT_DIR"
+mkdir -p logs
+export PYTHONPATH="$(dirname "$PROJECT_DIR"):$PROJECT_DIR:${PYTHONPATH:-}"
+
+python scripts/rollout_weight_reload_smoke.py \
+    --startup-delay "$STARTUP_DELAY" \
+    --timeout 90

--- a/tests/test_async_rl_trainer_weight_sync.py
+++ b/tests/test_async_rl_trainer_weight_sync.py
@@ -1,0 +1,119 @@
+import json
+from types import SimpleNamespace
+
+from RL_Framework.trainer.async_rl_trainer import AsyncRLTrainer
+
+
+def test_rollout_reload_requests_batch_and_reports_slowest_instance(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    checkpoint_path = tmp_path / "checkpoint"
+    checkpoint_path.mkdir()
+    control_dir = tmp_path / "control"
+    trainer = object.__new__(AsyncRLTrainer)
+    trainer.config = SimpleNamespace(
+        rollout_weight_sync_mode="restart",
+        require_rollout_weight_sync=True,
+        rollout_weight_sync_control_dir=str(control_dir),
+        rollout_weight_sync_timeout_s=5.0,
+        rollout_weight_reload_method="inplace",
+        rollout_weight_reload_strategy="parallel",
+    )
+    trainer._use_heterogeneous = False
+    trainer.rollout_engine = SimpleNamespace(num_instances=2)
+    responded = False
+
+    def respond_to_batch(_seconds):
+        nonlocal responded
+        request_path = control_dir / "reload_request.json"
+        if responded or not request_path.exists():
+            return
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        for instance_id, total_seconds in zip(
+            request["instance_ids"],
+            (1.25, 2.5),
+        ):
+            (control_dir / f"ack_{instance_id}_7.json").write_text(
+                json.dumps(
+                    {
+                        "instance_id": instance_id,
+                        "version": 7,
+                        "checkpoint_path": str(checkpoint_path),
+                        "reload_method": "inplace",
+                        "reload_strategy": "parallel",
+                        "total_seconds": total_seconds,
+                    }
+                ),
+                encoding="utf-8",
+            )
+        responded = True
+
+    monkeypatch.setattr(
+        "RL_Framework.trainer.async_rl_trainer.time.sleep",
+        respond_to_batch,
+    )
+
+    trainer._reload_rollout_from_checkpoint(str(checkpoint_path), 7)
+
+    request = json.loads(
+        (control_dir / "reload_request.json").read_text(encoding="utf-8")
+    )
+    assert request["reload_method"] == "inplace"
+    assert request["reload_strategy"] == "parallel"
+    assert request["instance_ids"] == ["instance_0", "instance_1"]
+    output = capsys.readouterr().out
+    assert "method=inplace" in output
+    assert "slowest_reload=2.50s" in output
+
+
+def test_serial_reload_strategy_is_preserved_in_batch_request(
+    tmp_path,
+    monkeypatch,
+):
+    checkpoint_path = tmp_path / "checkpoint"
+    checkpoint_path.mkdir()
+    control_dir = tmp_path / "control"
+    trainer = object.__new__(AsyncRLTrainer)
+    trainer.config = SimpleNamespace(
+        rollout_weight_sync_mode="restart",
+        require_rollout_weight_sync=True,
+        rollout_weight_sync_control_dir=str(control_dir),
+        rollout_weight_sync_timeout_s=5.0,
+        rollout_weight_reload_method="restart",
+        rollout_weight_reload_strategy="serial",
+    )
+    trainer._use_heterogeneous = False
+    trainer.rollout_engine = SimpleNamespace(num_instances=1)
+
+    def respond_to_batch(_seconds):
+        request = json.loads(
+            (control_dir / "reload_request.json").read_text(encoding="utf-8")
+        )
+        (control_dir / "ack_instance_0_3.json").write_text(
+            json.dumps(
+                {
+                    "instance_id": "instance_0",
+                    "version": 3,
+                    "checkpoint_path": str(checkpoint_path),
+                    "reload_method": "restart",
+                    "reload_strategy": request["reload_strategy"],
+                    "total_seconds": 1.0,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        "RL_Framework.trainer.async_rl_trainer.time.sleep",
+        respond_to_batch,
+    )
+
+    trainer._reload_rollout_from_checkpoint(str(checkpoint_path), 3)
+
+    request = json.loads(
+        (control_dir / "reload_request.json").read_text(encoding="utf-8")
+    )
+    assert request["reload_method"] == "restart"
+    assert request["reload_strategy"] == "serial"

--- a/tests/test_restartable_vllm_server.py
+++ b/tests/test_restartable_vllm_server.py
@@ -1,0 +1,57 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "restartable_vllm_server.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "restartable_vllm_server", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_atomic_ack_write_publishes_complete_payload(tmp_path):
+    module = _load_module()
+    ack_path = tmp_path / "ack_instance_1.json"
+
+    module.write_json_atomic(
+        ack_path,
+        {"version": 1, "reload_strategy": "parallel"},
+    )
+
+    assert json.loads(ack_path.read_text(encoding="utf-8")) == {
+        "version": 1,
+        "reload_strategy": "parallel",
+    }
+    assert list(tmp_path.iterdir()) == [ack_path]
+
+
+def test_parallel_is_default_reload_strategy(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "restartable_vllm_server.py",
+            "--instance-id",
+            "instance_0",
+            "--control-dir",
+            "/tmp/control",
+            "--health-url",
+            "http://127.0.0.1:8000/health",
+            "--initial-model",
+            "/tmp/model",
+            "--",
+            "python",
+            "server.py",
+        ],
+    )
+
+    args = module.parse_args()
+    assert args.reload_method == "restart"
+    assert args.reload_strategy == "parallel"

--- a/trainer/async_rl_trainer.py
+++ b/trainer/async_rl_trainer.py
@@ -1180,6 +1180,22 @@ class AsyncRLTrainer:
         control_dir.mkdir(parents=True, exist_ok=True)
 
         instance_ids = self._current_rollout_instance_ids()
+        reload_method = str(
+            getattr(self.config, "rollout_weight_reload_method", "restart")
+        ).lower()
+        if reload_method not in {"restart", "inplace"}:
+            raise ValueError(
+                "rollout_weight_reload_method must be 'restart' or 'inplace', "
+                f"got {reload_method!r}"
+            )
+        reload_strategy = str(
+            getattr(self.config, "rollout_weight_reload_strategy", "parallel")
+        ).lower()
+        if reload_strategy not in {"parallel", "serial"}:
+            raise ValueError(
+                "rollout_weight_reload_strategy must be 'parallel' or 'serial', "
+                f"got {reload_strategy!r}"
+            )
 
         for instance_id in instance_ids:
             (control_dir / f"ack_{instance_id}_{target_version}.json").unlink(
@@ -1191,12 +1207,9 @@ class AsyncRLTrainer:
         request = {
             "version": int(target_version),
             "checkpoint_path": checkpoint_path,
-            "reload_method": str(
-                getattr(self.config, "rollout_weight_reload_method", "restart")
-            ),
-            "reload_strategy": str(
-                getattr(self.config, "rollout_weight_reload_strategy", "parallel")
-            ),
+            "reload_method": reload_method,
+            "reload_strategy": reload_strategy,
+            "instance_ids": sorted(instance_ids),
             "created_at": time.time(),
         }
         request_tmp = control_dir / "reload_request.json.tmp"
@@ -1233,9 +1246,41 @@ class AsyncRLTrainer:
                 f"Timed out waiting for vLLM to loadversion={target_version}timed out，unconfirmed instances: "
                 f"{sorted(pending)}"
             )
+        acknowledgements = []
+        for instance_id in instance_ids:
+            ack_path = control_dir / f"ack_{instance_id}_{target_version}.json"
+            try:
+                ack = json.loads(ack_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise RuntimeError(
+                    f"Invalid rollout reload ACK: {ack_path}"
+                ) from exc
+            if (
+                str(ack.get("instance_id")) != instance_id
+                or int(ack.get("version", -1)) != int(target_version)
+                or str(ack.get("checkpoint_path")) != checkpoint_path
+                or str(ack.get("reload_method")) != reload_method
+                or str(ack.get("reload_strategy")) != reload_strategy
+            ):
+                raise RuntimeError(
+                    f"Mismatched rollout reload ACK for {instance_id}: {ack}"
+                )
+            acknowledgements.append(ack)
+
+        reload_seconds = [
+            float(ack["total_seconds"])
+            for ack in acknowledgements
+            if "total_seconds" in ack
+        ]
+        timing = (
+            f", slowest_reload={max(reload_seconds):.2f}s"
+            if reload_seconds
+            else ""
+        )
         print(
             f"Rollout weight refresh complete: version={target_version}, "
-            f"instances={len(instance_ids)}"
+            f"instances={len(instance_ids)}, method={reload_method}, "
+            f"strategy={reload_strategy}{timing}"
         )
 
     def _current_rollout_instance_ids(self) -> list[str]:


### PR DESCRIPTION
Default rollout checkpoint reloads to parallel execution while retaining the node-serialized fallback. Publish ACK and error files atomically, record per-instance phase timings, validate complete ACK batches in the trainer, and report the slowest reload. Add unit tests and a Slurm GPU test.