### PR TITLE
direct nccl rollout sync

### DIFF
--- a/config.py
+++ b/config.py
@@ -635,12 +635,16 @@ class AsyncRLConfig:
 
     weight_sync_mode: str = "disk"
     sync_path: str = "./logs/async_rl_weights"
-    rollout_weight_sync_mode: str = "none"  # none | restart
+    rollout_weight_sync_mode: str = "none"  # none | restart | nccl
     rollout_weight_sync_control_dir: str = ""
     rollout_weight_sync_timeout_s: float = 1200.0
     rollout_weight_sync_export_only: bool = True
     rollout_weight_reload_method: str = "restart"  # restart | inplace
     rollout_weight_reload_strategy: str = "parallel"  # parallel | serial
+    rollout_nccl_host: str = ""
+    rollout_nccl_port: int = 29620
+    rollout_nccl_chunk_mb: int = 256
+    rollout_nccl_rate_limit_gbps: float = 0.0
     require_rollout_weight_sync: bool = False
 
 
@@ -756,8 +760,10 @@ class AsyncRLConfig:
 
         if self.weight_sync_mode not in ["disk", "nccl"]:
             raise ValueError("weight_sync_mode must be 'disk' or 'nccl'")
-        if self.rollout_weight_sync_mode not in ["none", "restart"]:
-            raise ValueError("rollout_weight_sync_mode must be 'none' or 'restart'")
+        if self.rollout_weight_sync_mode not in ["none", "restart", "nccl"]:
+            raise ValueError(
+                "rollout_weight_sync_mode must be 'none', 'restart', or 'nccl'"
+            )
         if self.rollout_weight_reload_method not in ["restart", "inplace"]:
             raise ValueError(
                 "rollout_weight_reload_method must be 'restart' or 'inplace'"
@@ -766,6 +772,21 @@ class AsyncRLConfig:
             raise ValueError(
                 "rollout_weight_reload_strategy must be 'parallel' or 'serial'"
             )
+        if self.rollout_weight_sync_mode == "nccl":
+            if self.train_backend != "megatron_core":
+                raise ValueError(
+                    "NCCL rollout sync requires train_backend='megatron_core'"
+                )
+            if self.weight_sync_mode != "nccl":
+                raise ValueError(
+                    "NCCL rollout sync requires weight_sync_mode='nccl'"
+                )
+            if self.rollout_weight_reload_strategy != "parallel":
+                raise ValueError("NCCL rollout reload requires parallel strategy")
+            if self.rollout_nccl_chunk_mb <= 0:
+                raise ValueError("rollout_nccl_chunk_mb must be greater than zero")
+            if self.rollout_nccl_rate_limit_gbps < 0:
+                raise ValueError("rollout_nccl_rate_limit_gbps cannot be negative")
         if self.pipeline_schedule != "1f1b":
             raise ValueError("pipeline_schedule currently supports only '1f1b'")
         if self.virtual_pipeline_model_parallel_size != 0:
@@ -785,12 +806,19 @@ class AsyncRLConfig:
                 "batch_size must be divisible by train_dp_size * micro_batch_size: "
                 f"{self.batch_size} vs {self.train_dp_size}*{self.micro_batch_size}"
             )
-        if self.train_backend in {"megatron3d", "megatron_core"}:
-            if self.weight_sync_mode != "disk":
-                raise ValueError(
-                    "Megatron training backends support only weight_sync_mode='disk'"
-                )
+        if self.train_backend == "megatron3d" and self.weight_sync_mode != "disk":
+            raise ValueError(
+                "The legacy Megatron backend supports only weight_sync_mode='disk'"
+            )
         if self.train_backend == "megatron_core":
+            if self.weight_sync_mode not in {"disk", "nccl"}:
+                raise ValueError(
+                    "Megatron-Core weight_sync_mode must be 'disk' or 'nccl'"
+                )
+            if self.weight_sync_mode == "nccl" and self.rollout_weight_sync_mode != "nccl":
+                raise ValueError(
+                    "weight_sync_mode='nccl' requires rollout_weight_sync_mode='nccl'"
+                )
             if not 0.0 <= self.megatron_optimizer_offload_fraction <= 1.0:
                 raise ValueError(
                     "megatron_optimizer_offload_fraction must be between 0 and 1"

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -24,6 +24,10 @@ rollout_weight_sync_timeout_s: 1200
 rollout_weight_sync_export_only: true
 rollout_weight_reload_method: "restart"
 rollout_weight_reload_strategy: "parallel"
+rollout_nccl_host: ""
+rollout_nccl_port: 29620
+rollout_nccl_chunk_mb: 256
+rollout_nccl_rate_limit_gbps: 0.0
 require_rollout_weight_sync: false
 
 

--- a/docs/megatron_core_backend.md
+++ b/docs/megatron_core_backend.md
@@ -101,6 +101,11 @@ group. The trainer pauses rollout dispatch and sends bounded chunks outside
 gradient collectives. Set a positive `rollout_nccl_rate_limit_gbps` when the
 rollout and training jobs share an InfiniBand fabric.
 
+The communicator is cached by transport identity inside the Megatron and vLLM
+processes. Keep `rollout_nccl_port` stable across refreshes so later versions
+reuse the initialized NCCL/TCPStore connection. A topology change or process
+restart creates a new communicator automatically.
+
 Libra defaults the independent communicator to `NCCL_CUMEM_ENABLE=0` to match
 vLLM 0.9.x worker communicators. Do not configure different cuMem modes on the
 Megatron sender and vLLM receivers; mixed CUMEM/IPC transports fail during

--- a/docs/megatron_core_backend.md
+++ b/docs/megatron_core_backend.md
@@ -8,10 +8,10 @@ with two collective, bounded-memory operations:
    `optimizer.sharded_state_dict(...)` are saved with Megatron-Core
    `torch_dist` distributed checkpointing.
 2. Megatron Bridge collectively streams converted Hugging Face tensors.
-   All ranks participate in TP/EP conversion, while rank 0 writes the
-   original safetensors shard layout. The writer buffers at most one original
-   safetensors file shard; no rank constructs a full HF model or a full model
-   state dictionary.
+   All ranks participate in TP/EP conversion. For disk sync, rank 0 writes the
+   original safetensors shard layout. With `weight_sync_mode=nccl`, rank 0
+   broadcasts each tensor directly from GPU memory to all vLLM workers; no
+   rollout checkpoint or safetensors file is created.
 
 MCore 0.14's non-Transformer-Engine `GroupedMLP` stores every local expert in
 two expert-major tensors, `weight1` and `weight2`. Megatron Bridge 0.2 does not
@@ -80,6 +80,37 @@ sbatch scripts/submit_r2e_gym_cmlfq_megatron_core_qwen3_30b_a3b.slurm
 The native distributed checkpoint is the source of truth for training
 resume. The Hugging Face safetensors files are an interoperability artifact
 used only to restart vLLM rollout workers at the configured sync interval.
+
+## Direct NCCL rollout refresh
+
+```yaml
+train_backend: megatron_core
+weight_sync_mode: nccl
+rollout_weight_sync_mode: nccl
+rollout_weight_sync_control_dir: /path/to/run/rollout_weight_sync
+rollout_nccl_host: 10.0.0.10
+rollout_nccl_port: 29620
+rollout_nccl_chunk_mb: 256
+rollout_nccl_rate_limit_gbps: 0.0
+```
+
+Both rollout instances enter `/reload_weights_nccl` concurrently. Metadata
+uses `StatelessProcessGroup`, while tensors use an isolated
+`PyNcclCommunicator`, so this path does not alter Megatron's training process
+group. The trainer pauses rollout dispatch and sends bounded chunks outside
+gradient collectives. Set a positive `rollout_nccl_rate_limit_gbps` when the
+rollout and training jobs share an InfiniBand fabric.
+
+Libra defaults the independent communicator to `NCCL_CUMEM_ENABLE=0` to match
+vLLM 0.9.x worker communicators. Do not configure different cuMem modes on the
+Megatron sender and vLLM receivers; mixed CUMEM/IPC transports fail during
+communicator initialization.
+
+Wire volume is approximately `parameter_count * dtype_bytes` per rollout
+worker and refresh. Same-node peers normally use NVLink/PCIe; cross-node peers
+use InfiniBand. Two rollout instances increase fan-out traffic, but avoid all
+model checkpoint I/O. The refresh log reports bytes and elapsed seconds for
+effective-bandwidth and congestion monitoring.
 
 ## Verification
 

--- a/engine/megatron_core_train_engine.py
+++ b/engine/megatron_core_train_engine.py
@@ -553,6 +553,16 @@ class MegatronCoreTrainEngine:
             export_for_rollout=self.streaming_export,
         )
 
+    def stream_rollout_weights(self):
+        """Yield complete HF-format tensors directly from GPU memory."""
+        if self.bridge is None or not self.model:
+            raise RuntimeError("Megatron Bridge/model is not initialized")
+        return self.bridge.export_hf_weights(
+            self.model,
+            cpu=False,
+            show_progress=self.is_main_process,
+        )
+
     def load_weights(self, path: str, version: int):
         if Path(path) != self.checkpoints.sync_path:
             self.checkpoints.sync_path = Path(path)

--- a/infra/sync/nccl_weight_sync.py
+++ b/infra/sync/nccl_weight_sync.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import os
+import threading
 import time
 from dataclasses import dataclass
 from typing import Callable, Iterable, Iterator
 
 import torch
+
+
+_COMMUNICATOR_CACHE: dict[tuple[str, int, int, int, str], object] = {}
+_COMMUNICATOR_CACHE_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -56,9 +61,21 @@ def _communicator(spec: NcclReloadSpec):
             self._constructor_warmup_output = result
             return result
 
-    communicator = _BroadcastCommunicator(_group(spec), device=spec.device)
-    communicator._constructor_warmup_output = None
-    return communicator
+    device = str(torch.device(spec.device))
+    key = (str(spec.host), int(spec.port), int(spec.world_size), int(spec.rank), device)
+    with _COMMUNICATOR_CACHE_LOCK:
+        communicator = _COMMUNICATOR_CACHE.get(key)
+        if communicator is None:
+            communicator = _BroadcastCommunicator(_group(spec), device=spec.device)
+            communicator._constructor_warmup_output = None
+            _COMMUNICATOR_CACHE[key] = communicator
+        return communicator
+
+
+def clear_communicator_cache() -> None:
+    """Drop cached communicators, typically during orderly process shutdown."""
+    with _COMMUNICATOR_CACHE_LOCK:
+        _COMMUNICATOR_CACHE.clear()
 
 
 def _dtype_name(dtype: torch.dtype) -> str:

--- a/infra/sync/nccl_weight_sync.py
+++ b/infra/sync/nccl_weight_sync.py
@@ -1,0 +1,143 @@
+"""Direct GPU/NCCL weight transport between Megatron and vLLM workers."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable, Iterator
+
+import torch
+
+
+@dataclass(frozen=True)
+class NcclReloadSpec:
+    """Connection parameters for one reload generation."""
+
+    host: str
+    port: int
+    world_size: int
+    rank: int
+    device: str | int
+    timeout_s: float = 1200.0
+    chunk_bytes: int = 256 * 1024 * 1024
+    rate_limit_gbps: float = 0.0
+
+
+def _group(spec: NcclReloadSpec):
+    from vllm.distributed.utils import StatelessProcessGroup
+
+    return StatelessProcessGroup.create(
+        host=spec.host,
+        port=int(spec.port),
+        rank=int(spec.rank),
+        world_size=int(spec.world_size),
+        store_timeout=max(30, int(spec.timeout_s)),
+    )
+
+
+def _communicator(spec: NcclReloadSpec):
+    # vLLM 0.9.x disables cuMem for its worker communicators. All ranks in
+    # this independent communicator must use the same transport mode.
+    os.environ.setdefault("NCCL_CUMEM_ENABLE", "0")
+    from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+
+    class _BroadcastCommunicator(PyNcclCommunicator):
+        """Keep vLLM's constructor warm-up output alive until it synchronizes."""
+
+        def all_reduce(self, in_tensor, op=None, stream=None):
+            # vLLM 0.9.x discards the out-of-place all-reduce result in
+            # PyNcclCommunicator.__init__. Retain it so the CUDA allocator does
+            # not recycle the receive buffer while the warm-up is in flight.
+            if op is None:
+                result = super().all_reduce(in_tensor, stream=stream)
+            else:
+                result = super().all_reduce(in_tensor, op=op, stream=stream)
+            self._constructor_warmup_output = result
+            return result
+
+    communicator = _BroadcastCommunicator(_group(spec), device=spec.device)
+    communicator._constructor_warmup_output = None
+    return communicator
+
+
+def _dtype_name(dtype: torch.dtype) -> str:
+    return str(dtype).replace("torch.", "")
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    value = getattr(torch, name, None)
+    if not isinstance(value, torch.dtype):
+        raise ValueError(f"Unsupported NCCL weight dtype: {name}")
+    return value
+
+
+def send_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    spec: NcclReloadSpec,
+    *,
+    on_tensor: Callable[[str, int], None] | None = None,
+) -> int:
+    """Broadcast full HF-format tensors from rank zero to vLLM workers.
+
+    The caller must invoke this on every Megatron rank because the bridge
+    export performs TP/PP collectives on every rank. Only rank zero enters the
+    NCCL sender; other ranks still consume the generator and discard tensors.
+    """
+    if spec.rank != 0:
+        raise ValueError("send_weights must run with rank=0")
+    comm = _communicator(spec)
+    count = 0
+    for name, tensor in weights:
+        if tensor.device.type != "cuda":
+            tensor = tensor.to(device=spec.device, non_blocking=True)
+        tensor = tensor.contiguous()
+        chunk_numel = max(1, int(spec.chunk_bytes) // tensor.element_size())
+        metadata = {
+            "done": False,
+            "name": str(name),
+            "shape": list(tensor.shape),
+            "dtype": _dtype_name(tensor.dtype),
+            "chunk_numel": chunk_numel,
+        }
+        comm.group.broadcast_obj(metadata, src=0)
+        flat = tensor.view(-1)
+        for start in range(0, flat.numel(), chunk_numel):
+            chunk = flat[start : start + chunk_numel]
+            chunk_started = time.perf_counter()
+            comm.broadcast(chunk, src=0)
+            torch.cuda.current_stream(tensor.device).synchronize()
+            if spec.rate_limit_gbps > 0:
+                target_seconds = (
+                    chunk.numel() * chunk.element_size() * 8
+                ) / (spec.rate_limit_gbps * 1e9)
+                elapsed = time.perf_counter() - chunk_started
+                if elapsed < target_seconds:
+                    time.sleep(target_seconds - elapsed)
+        count += 1
+        if on_tensor is not None:
+            on_tensor(str(name), int(tensor.numel() * tensor.element_size()))
+    comm.group.broadcast_obj({"done": True}, src=0)
+    return count
+
+
+def receive_weights(spec: NcclReloadSpec) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield NCCL-received HF tensors for vLLM's ``load_weights`` method."""
+    comm = _communicator(spec)
+    while True:
+        metadata = comm.group.broadcast_obj(None, src=0)
+        if metadata.get("done", False):
+            return
+        shape = tuple(int(value) for value in metadata["shape"])
+        tensor = torch.empty(
+            shape,
+            dtype=_dtype_from_name(str(metadata["dtype"])),
+            device=spec.device,
+        )
+        flat = tensor.view(-1)
+        chunk_numel = max(1, int(metadata["chunk_numel"]))
+        for start in range(0, flat.numel(), chunk_numel):
+            chunk = flat[start : start + chunk_numel]
+            comm.broadcast(chunk, src=0)
+            torch.cuda.current_stream(tensor.device).synchronize()
+        yield str(metadata["name"]), tensor

--- a/infra/sync/nccl_weight_sync.py
+++ b/infra/sync/nccl_weight_sync.py
@@ -77,6 +77,7 @@ def send_weights(
     spec: NcclReloadSpec,
     *,
     on_tensor: Callable[[str, int], None] | None = None,
+    keepalive: list[object] | None = None,
 ) -> int:
     """Broadcast full HF-format tensors from rank zero to vLLM workers.
 
@@ -87,6 +88,10 @@ def send_weights(
     if spec.rank != 0:
         raise ValueError("send_weights must run with rank=0")
     comm = _communicator(spec)
+    if keepalive is not None:
+        # The receivers may still be consuming the final metadata marker after
+        # this function returns. Keep the TCPStore alive until their RPC acks.
+        keepalive.append(comm)
     count = 0
     for name, tensor in weights:
         if tensor.device.type != "cuda":

--- a/scripts/direct_nccl_qwen3_probe.py
+++ b/scripts/direct_nccl_qwen3_probe.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""End-to-end Megatron Bridge to two vLLM NCCL reload probe."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+from pathlib import Path
+import time
+import urllib.request
+
+import torch
+import torch.distributed as dist
+
+from RL_Framework.engine.megatron_core_train_engine import MegatronCoreTrainEngine
+from RL_Framework.infra.sync.nccl_weight_sync import NcclReloadSpec, send_weights
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--endpoints", required=True)
+    parser.add_argument("--served-model-name", default="qwen3-probe")
+    parser.add_argument("--transport-host", required=True)
+    parser.add_argument("--transport-port", type=int, default=29620)
+    parser.add_argument("--train-tp", type=int, default=1)
+    parser.add_argument("--train-ep", type=int, default=1)
+    parser.add_argument("--chunk-mb", type=int, default=256)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args()
+
+
+def post_json(url: str, payload: dict, timeout: float) -> dict:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def completion(endpoint: str, served_model_name: str) -> dict:
+    body = post_json(
+        f"{endpoint}/v1/completions",
+        {
+            "model": served_model_name,
+            "prompt": "Compute 17 * 19. The answer is",
+            "max_tokens": 8,
+            "temperature": 0.0,
+        },
+        120.0,
+    )
+    text = body["choices"][0]["text"]
+    return {
+        "text": text,
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    endpoints = [value.rstrip("/") for value in args.endpoints.split(",")]
+    if len(endpoints) != 2:
+        raise ValueError("The probe requires exactly two vLLM endpoints")
+    if world_size != args.train_tp:
+        raise ValueError("torchrun world size must equal --train-tp")
+
+    engine = MegatronCoreTrainEngine(
+        model_path=args.model,
+        train_tp_size=args.train_tp,
+        train_ep_size=args.train_ep,
+        expert_tensor_parallel_size=1,
+        sequence_parallel=args.train_tp > 1,
+        use_distributed_optimizer=False,
+        streaming_export=True,
+        use_transformer_engine=False,
+        use_cpu_initialization=False,
+    )
+    engine.initialize(max_seq_length=512, initialize_optimizer=False)
+    if dist.is_initialized():
+        dist.barrier()
+
+    before = None
+    futures = None
+    executor = None
+    if rank == 0:
+        before = {
+            endpoint: completion(endpoint, args.served_model_name)
+            for endpoint in endpoints
+        }
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+        futures = {
+            endpoint: executor.submit(
+                post_json,
+                f"{endpoint}/reload_weights_nccl",
+                {
+                    "host": args.transport_host,
+                    "port": args.transport_port,
+                    "world_size": 3,
+                    "rank_offset": index,
+                    "timeout_seconds": 1800.0,
+                    "chunk_bytes": args.chunk_mb * 1024 * 1024,
+                },
+                1810.0,
+            )
+            for index, endpoint in enumerate(endpoints)
+        }
+
+    if dist.is_initialized():
+        dist.barrier()
+    weights = engine.stream_rollout_weights()
+    started = time.perf_counter()
+    tensor_count = 0
+    transferred_bytes = 0
+    if rank == 0:
+        def record_tensor(_name: str, size_bytes: int) -> None:
+            nonlocal transferred_bytes
+            transferred_bytes += size_bytes
+
+        tensor_count = send_weights(
+            weights,
+            NcclReloadSpec(
+                host=args.transport_host,
+                port=args.transport_port,
+                world_size=3,
+                rank=0,
+                device=torch.cuda.current_device(),
+                timeout_s=1800.0,
+                chunk_bytes=args.chunk_mb * 1024 * 1024,
+            ),
+            on_tensor=record_tensor,
+        )
+    else:
+        for _name, tensor in weights:
+            del tensor
+    if dist.is_initialized():
+        dist.barrier()
+
+    if rank == 0:
+        responses = {
+            endpoint: future.result()
+            for endpoint, future in futures.items()
+        }
+        executor.shutdown(wait=True)
+        total_seconds = time.perf_counter() - started
+        after = {
+            endpoint: completion(endpoint, args.served_model_name)
+            for endpoint in endpoints
+        }
+        payload = {
+            "model": args.model,
+            "train_tp": args.train_tp,
+            "train_ep": args.train_ep,
+            "tensor_count": tensor_count,
+            "transferred_bytes": transferred_bytes,
+            "fanout_bytes": transferred_bytes * 2,
+            "total_seconds": total_seconds,
+            "payload_gib_per_second": (
+                transferred_bytes / (1024**3) / total_seconds
+            ),
+            "before": before,
+            "after": after,
+            "outputs_stable": before == after,
+            "responses": responses,
+        }
+        output = Path(args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(json.dumps(payload, indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/direct_nccl_qwen3_probe.py
+++ b/scripts/direct_nccl_qwen3_probe.py
@@ -10,6 +10,7 @@ import json
 import os
 from pathlib import Path
 import time
+import urllib.error
 import urllib.request
 
 import torch
@@ -40,8 +41,12 @@ def post_json(url: str, payload: dict, timeout: float) -> dict:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        return json.loads(response.read().decode("utf-8"))
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"POST {url} returned HTTP {exc.code}: {detail}") from exc
 
 
 def completion(endpoint: str, served_model_name: str) -> dict:
@@ -119,6 +124,7 @@ def main() -> int:
     started = time.perf_counter()
     tensor_count = 0
     transferred_bytes = 0
+    transport_keepalive: list[object] = []
     if rank == 0:
         def record_tensor(_name: str, size_bytes: int) -> None:
             nonlocal transferred_bytes
@@ -136,6 +142,7 @@ def main() -> int:
                 chunk_bytes=args.chunk_mb * 1024 * 1024,
             ),
             on_tensor=record_tensor,
+            keepalive=transport_keepalive,
         )
     else:
         for _name, tensor in weights:
@@ -144,11 +151,13 @@ def main() -> int:
         dist.barrier()
 
     if rank == 0:
+        send_finished = time.perf_counter()
         responses = {
             endpoint: future.result()
             for endpoint, future in futures.items()
         }
         executor.shutdown(wait=True)
+        transport_keepalive.clear()
         total_seconds = time.perf_counter() - started
         after = {
             endpoint: completion(endpoint, args.served_model_name)
@@ -162,6 +171,7 @@ def main() -> int:
             "transferred_bytes": transferred_bytes,
             "fanout_bytes": transferred_bytes * 2,
             "total_seconds": total_seconds,
+            "send_seconds": send_finished - started,
             "payload_gib_per_second": (
                 transferred_bytes / (1024**3) / total_seconds
             ),

--- a/scripts/direct_nccl_qwen3_probe.py
+++ b/scripts/direct_nccl_qwen3_probe.py
@@ -30,6 +30,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--train-tp", type=int, default=1)
     parser.add_argument("--train-ep", type=int, default=1)
     parser.add_argument("--chunk-mb", type=int, default=256)
+    parser.add_argument("--repeats", type=int, default=1)
     parser.add_argument("--output", required=True)
     return parser.parse_args()
 
@@ -92,93 +93,116 @@ def main() -> int:
     if dist.is_initialized():
         dist.barrier()
 
+    if args.repeats <= 0:
+        raise ValueError("--repeats must be positive")
     before = None
-    futures = None
-    executor = None
+    rounds = []
+    transport_keepalive: list[object] = []
     if rank == 0:
         before = {
             endpoint: completion(endpoint, args.served_model_name)
             for endpoint in endpoints
         }
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
-        futures = {
-            endpoint: executor.submit(
-                post_json,
-                f"{endpoint}/reload_weights_nccl",
-                {
-                    "host": args.transport_host,
-                    "port": args.transport_port,
-                    "world_size": 3,
-                    "rank_offset": index,
-                    "timeout_seconds": 1800.0,
-                    "chunk_bytes": args.chunk_mb * 1024 * 1024,
-                },
-                1810.0,
+    for round_index in range(args.repeats):
+        futures = None
+        executor = None
+        if rank == 0:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+            futures = {
+                endpoint: executor.submit(
+                    post_json,
+                    f"{endpoint}/reload_weights_nccl",
+                    {
+                        "host": args.transport_host,
+                        "port": args.transport_port,
+                        "world_size": 3,
+                        "rank_offset": index,
+                        "timeout_seconds": 1800.0,
+                        "chunk_bytes": args.chunk_mb * 1024 * 1024,
+                    },
+                    1810.0,
+                )
+                for index, endpoint in enumerate(endpoints)
+            }
+        if dist.is_initialized():
+            dist.barrier()
+        weights = engine.stream_rollout_weights()
+        started = time.perf_counter()
+        tensor_count = 0
+        transferred_bytes = 0
+        if rank == 0:
+            def record_tensor(_name: str, size_bytes: int) -> None:
+                nonlocal transferred_bytes
+                transferred_bytes += size_bytes
+
+            tensor_count = send_weights(
+                weights,
+                NcclReloadSpec(
+                    host=args.transport_host,
+                    port=args.transport_port,
+                    world_size=3,
+                    rank=0,
+                    device=torch.cuda.current_device(),
+                    timeout_s=1800.0,
+                    chunk_bytes=args.chunk_mb * 1024 * 1024,
+                ),
+                on_tensor=record_tensor,
+                keepalive=transport_keepalive,
             )
-            for index, endpoint in enumerate(endpoints)
-        }
-
-    if dist.is_initialized():
-        dist.barrier()
-    weights = engine.stream_rollout_weights()
-    started = time.perf_counter()
-    tensor_count = 0
-    transferred_bytes = 0
-    transport_keepalive: list[object] = []
+        else:
+            for _name, tensor in weights:
+                del tensor
+        if dist.is_initialized():
+            dist.barrier()
+        if rank == 0:
+            send_finished = time.perf_counter()
+            responses = {
+                endpoint: future.result()
+                for endpoint, future in futures.items()
+            }
+            executor.shutdown(wait=True)
+            transport_keepalive.clear()
+            after = {
+                endpoint: completion(endpoint, args.served_model_name)
+                for endpoint in endpoints
+            }
+            total_seconds = time.perf_counter() - started
+            rounds.append(
+                {
+                    "round": round_index + 1,
+                    "tensor_count": tensor_count,
+                    "transferred_bytes": transferred_bytes,
+                    "fanout_bytes": transferred_bytes * 2,
+                    "total_seconds": total_seconds,
+                    "send_seconds": send_finished - started,
+                    "payload_gib_per_second": (
+                        transferred_bytes
+                        / (1024**3)
+                        / total_seconds
+                    ),
+                    "after": after,
+                    "responses": responses,
+                }
+            )
     if rank == 0:
-        def record_tensor(_name: str, size_bytes: int) -> None:
-            nonlocal transferred_bytes
-            transferred_bytes += size_bytes
-
-        tensor_count = send_weights(
-            weights,
-            NcclReloadSpec(
-                host=args.transport_host,
-                port=args.transport_port,
-                world_size=3,
-                rank=0,
-                device=torch.cuda.current_device(),
-                timeout_s=1800.0,
-                chunk_bytes=args.chunk_mb * 1024 * 1024,
-            ),
-            on_tensor=record_tensor,
-            keepalive=transport_keepalive,
-        )
-    else:
-        for _name, tensor in weights:
-            del tensor
-    if dist.is_initialized():
-        dist.barrier()
-
-    if rank == 0:
-        send_finished = time.perf_counter()
-        responses = {
-            endpoint: future.result()
-            for endpoint, future in futures.items()
-        }
-        executor.shutdown(wait=True)
-        transport_keepalive.clear()
-        total_seconds = time.perf_counter() - started
-        after = {
-            endpoint: completion(endpoint, args.served_model_name)
-            for endpoint in endpoints
-        }
+        final_round = rounds[-1]
         payload = {
             "model": args.model,
             "train_tp": args.train_tp,
             "train_ep": args.train_ep,
-            "tensor_count": tensor_count,
-            "transferred_bytes": transferred_bytes,
-            "fanout_bytes": transferred_bytes * 2,
-            "total_seconds": total_seconds,
-            "send_seconds": send_finished - started,
-            "payload_gib_per_second": (
-                transferred_bytes / (1024**3) / total_seconds
-            ),
+            "repeats": args.repeats,
+            "tensor_count": final_round["tensor_count"],
+            "transferred_bytes": final_round["transferred_bytes"],
+            "fanout_bytes": final_round["fanout_bytes"],
+            "total_seconds": final_round["total_seconds"],
+            "send_seconds": final_round["send_seconds"],
+            "payload_gib_per_second": final_round["payload_gib_per_second"],
             "before": before,
-            "after": after,
-            "outputs_stable": before == after,
-            "responses": responses,
+            "after": final_round["after"],
+            "outputs_stable": all(
+                before == round_result["after"] for round_result in rounds
+            ),
+            "rounds": rounds,
         }
         output = Path(args.output)
         output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/restartable_vllm_server.py
+++ b/scripts/restartable_vllm_server.py
@@ -76,6 +76,25 @@ def reload_inplace(health_url: str, checkpoint_path: str, timeout: float) -> dic
         return json.loads(response.read().decode("utf-8"))
 
 
+def reload_nccl(
+    health_url: str,
+    payload: dict,
+    timeout: float,
+) -> dict:
+    """Ask a resident vLLM server to receive weights over NCCL."""
+    endpoint = health_url.rsplit("/", 1)[0] + "/reload_weights_nccl"
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout + 10) as response:
+        if response.status != 200:
+            raise RuntimeError(f"vLLM NCCL reload returned HTTP {response.status}")
+        return json.loads(response.read().decode("utf-8"))
+
+
 def stop_process(process: subprocess.Popen | None) -> None:
     if process is None or process.poll() is not None:
         return
@@ -140,14 +159,17 @@ def main() -> int:
                 try:
                     request = json.loads(request_path.read_text(encoding="utf-8"))
                     requested_version = int(request["version"])
-                    checkpoint_path = str(request["checkpoint_path"])
+                    reload_mode = str(request.get("mode", "checkpoint")).lower()
+                    checkpoint_path = str(request.get("checkpoint_path", ""))
                     reload_method = str(
                         request.get("reload_method", args.reload_method)
                     ).lower()
                     reload_strategy = str(
                         request.get("reload_strategy", args.reload_strategy)
                     ).lower()
-                    if reload_method not in {"restart", "inplace"}:
+                    if reload_mode not in {"checkpoint", "nccl"}:
+                        raise ValueError(f"unsupported reload mode: {reload_mode}")
+                    if reload_mode == "checkpoint" and reload_method not in {"restart", "inplace"}:
                         raise ValueError(f"unsupported reload method: {reload_method}")
                     if reload_strategy not in {"parallel", "serial"}:
                         raise ValueError(f"unsupported reload strategy: {reload_strategy}")
@@ -155,7 +177,7 @@ def main() -> int:
                     time.sleep(max(0.05, args.poll_interval))
                     continue
                 if requested_version > current_version:
-                    if not Path(checkpoint_path).is_dir():
+                    if reload_mode == "checkpoint" and not Path(checkpoint_path).is_dir():
                         raise FileNotFoundError(checkpoint_path)
                     current_version = requested_version
                     reload_started_at = time.time()
@@ -163,12 +185,28 @@ def main() -> int:
                     try:
                         reload_guard = (
                             node_reload_lock(control_dir)
-                            if reload_strategy == "serial"
+                            if reload_strategy == "serial" and reload_mode != "nccl"
                             else contextlib.nullcontext()
                         )
                         with reload_guard:
                             guard_acquired_at = time.time()
-                            if reload_method == "restart":
+                            if reload_mode == "nccl":
+                                stopped_at = guard_acquired_at
+                                response = reload_nccl(
+                                    args.health_url,
+                                    {
+                                        "host": str(request["nccl_host"]),
+                                        "port": int(request["nccl_port"]),
+                                        "world_size": int(request["nccl_world_size"]),
+                                        "rank_offset": int(
+                                            request["nccl_rank_offsets"][args.instance_id]
+                                        ),
+                                        "timeout_seconds": float(args.ready_timeout),
+                                        "chunk_bytes": int(request["nccl_chunk_bytes"]),
+                                    },
+                                    args.ready_timeout,
+                                )
+                            elif reload_method == "restart":
                                 stop_process(process)
                                 stopped_at = time.time()
                                 process = launch(checkpoint_path)

--- a/scripts/submit_qwen3_direct_nccl_probe.slurm
+++ b/scripts/submit_qwen3_direct_nccl_probe.slurm
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#SBATCH -J qwen3-direct-nccl
+#SBATCH -A nsgm_xu
+#SBATCH --qos=normal
+#SBATCH -p gpu
+#SBATCH --exclude=gn021
+#SBATCH -N 1
+#SBATCH -G 3
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=48
+#SBATCH --mem=384G
+#SBATCH --time=02:00:00
+
+set -euo pipefail
+
+MODEL_NAME="${MODEL_NAME:?MODEL_NAME is required}"
+TRAIN_TP="${TRAIN_TP:-2}"
+TRAIN_EP="${TRAIN_EP:-1}"
+BASE_PORT="${BASE_PORT:-18500}"
+TRANSPORT_PORT="${TRANSPORT_PORT:-29620}"
+VLLM_GPU_MEMORY_UTILIZATION="${VLLM_GPU_MEMORY_UTILIZATION:-0.82}"
+ROOT="$HOME/kwchen/rlinf_baseline"
+PROJECT="$ROOT/libra_nccl_dev/RL_Framework"
+MODEL="$HOME/kwchen/hf_models/$MODEL_NAME"
+RESULTS="$ROOT/libra_results/direct_nccl_${MODEL_NAME}_${SLURM_JOB_ID}"
+
+source "$HOME/rl_framework_env/bin/activate"
+export PYTHONPATH="$ROOT/libra_nccl_dev:${PYTHONPATH:-}"
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export NCCL_DEBUG="${NCCL_DEBUG:-INFO}"
+export NCCL_DEBUG_SUBSYS="${NCCL_DEBUG_SUBSYS:-INIT,ENV}"
+export NCCL_CUMEM_ENABLE="${NCCL_CUMEM_ENABLE:-0}"
+mkdir -p "$RESULTS"
+
+ALLOCATED_CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3}"
+IFS=',' read -r -a GPU_IDS <<< "$ALLOCATED_CUDA_VISIBLE_DEVICES"
+REQUIRED_GPUS=$((2 + TRAIN_TP))
+if ((${#GPU_IDS[@]} < REQUIRED_GPUS)); then
+  echo "Expected $REQUIRED_GPUS allocated GPUs, got: $ALLOCATED_CUDA_VISIBLE_DEVICES" >&2
+  exit 1
+fi
+
+server_steps=()
+cleanup() {
+  if ((${#server_steps[@]})); then
+    kill "${server_steps[@]}" >/dev/null 2>&1 || true
+    wait "${server_steps[@]}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+for instance in 0 1; do
+  port=$((BASE_PORT + instance))
+  CUDA_VISIBLE_DEVICES="${GPU_IDS[$instance]}" \
+    python "$PROJECT/scripts/vllm_hot_reload_api_server.py" \
+      --model "$MODEL" \
+      --served-model-name qwen3-probe \
+      --host 0.0.0.0 \
+      --port "$port" \
+      --tensor-parallel-size 1 \
+      --max-model-len 512 \
+      --max-num-seqs 4 \
+      --dtype bfloat16 \
+      --gpu-memory-utilization "$VLLM_GPU_MEMORY_UTILIZATION" \
+      --enforce-eager \
+      --enable-prefix-caching \
+      --trust-remote-code \
+      --worker-extension-cls RL_Framework.vllm_hot_reload.InplaceReloadWorkerExtension \
+      >"$RESULTS/vllm_${instance}.log" 2>&1 &
+  server_steps+=("$!")
+done
+
+for instance in 0 1; do
+  port=$((BASE_PORT + instance))
+  for _ in $(seq 1 600); do
+    if curl -fsS "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 2
+  done
+  curl -fsS "http://127.0.0.1:${port}/health" >/dev/null
+done
+
+NODE_IP="127.0.0.1"
+MASTER_PORT=$((TRANSPORT_PORT + 1000))
+TRAINER_CUDA_VISIBLE_DEVICES="${GPU_IDS[2]}"
+if ((TRAIN_TP > 1)); then
+  for ((index = 3; index < REQUIRED_GPUS; index++)); do
+    TRAINER_CUDA_VISIBLE_DEVICES+=",${GPU_IDS[$index]}"
+  done
+fi
+CUDA_VISIBLE_DEVICES="$TRAINER_CUDA_VISIBLE_DEVICES" \
+  torchrun --standalone --nnodes=1 --nproc-per-node="$TRAIN_TP" \
+    --master-port="$MASTER_PORT" \
+    "$PROJECT/scripts/direct_nccl_qwen3_probe.py" \
+      --model "$MODEL" \
+      --endpoints "http://127.0.0.1:${BASE_PORT},http://127.0.0.1:$((BASE_PORT + 1))" \
+      --transport-host "$NODE_IP" \
+      --transport-port "$TRANSPORT_PORT" \
+      --train-tp "$TRAIN_TP" \
+      --train-ep "$TRAIN_EP" \
+      --output "$RESULTS/result.json" \
+      >"$RESULTS/trainer.log" 2>&1

--- a/scripts/submit_qwen3_direct_nccl_probe.slurm
+++ b/scripts/submit_qwen3_direct_nccl_probe.slurm
@@ -19,6 +19,7 @@ TRAIN_EP="${TRAIN_EP:-1}"
 BASE_PORT="${BASE_PORT:-18500}"
 TRANSPORT_PORT="${TRANSPORT_PORT:-29620}"
 VLLM_GPU_MEMORY_UTILIZATION="${VLLM_GPU_MEMORY_UTILIZATION:-0.82}"
+PROBE_REPEATS="${PROBE_REPEATS:-1}"
 ROOT="$HOME/kwchen/rlinf_baseline"
 PROJECT="$ROOT/libra_nccl_dev/RL_Framework"
 MODEL="$HOME/kwchen/hf_models/$MODEL_NAME"
@@ -99,5 +100,6 @@ CUDA_VISIBLE_DEVICES="$TRAINER_CUDA_VISIBLE_DEVICES" \
       --transport-port "$TRANSPORT_PORT" \
       --train-tp "$TRAIN_TP" \
       --train-ep "$TRAIN_EP" \
+      --repeats "$PROBE_REPEATS" \
       --output "$RESULTS/result.json" \
       >"$RESULTS/trainer.log" 2>&1

--- a/scripts/vllm_hot_reload_api_server.py
+++ b/scripts/vllm_hot_reload_api_server.py
@@ -24,6 +24,17 @@ class ReloadWeightsRequest(BaseModel):
     timeout_seconds: float = 300.0
 
 
+class ReloadWeightsNcclRequest(BaseModel):
+    """Payload for a direct Megatron-to-vLLM NCCL reload."""
+
+    host: str
+    port: int
+    world_size: int
+    rank_offset: int
+    timeout_seconds: float = 1200.0
+    chunk_bytes: int = 268435456
+
+
 _reload_lock = asyncio.Lock()
 
 
@@ -49,6 +60,37 @@ async def reload_weights(payload: ReloadWeightsRequest, request: Request):
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         return {
             "checkpoint_path": str(checkpoint),
+            "total_seconds": time.perf_counter() - started,
+            "workers": results,
+        }
+
+
+@api_server.router.post("/reload_weights_nccl")
+async def reload_weights_nccl(
+    payload: ReloadWeightsNcclRequest,
+    request: Request,
+):
+    """Receive the next model directly from the Megatron GPU stream."""
+    async with _reload_lock:
+        started = time.perf_counter()
+        client = api_server.engine_client(request)
+        try:
+            results = await client.collective_rpc(
+                "reload_weights_nccl",
+                timeout=payload.timeout_seconds,
+                args=(
+                    payload.host,
+                    payload.port,
+                    payload.world_size,
+                    payload.rank_offset,
+                    payload.timeout_seconds,
+                    payload.chunk_bytes,
+                ),
+            )
+            await client.reset_prefix_cache()
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return {
             "total_seconds": time.perf_counter() - started,
             "workers": results,
         }

--- a/tests/test_megatron_core_config.py
+++ b/tests/test_megatron_core_config.py
@@ -112,3 +112,31 @@ def test_rejects_unknown_rollout_weight_reload_method():
 def test_rejects_unknown_rollout_weight_reload_strategy():
     with pytest.raises(ValueError, match="rollout_weight_reload_strategy"):
         make_config(rollout_weight_reload_strategy="unknown")
+
+
+def test_direct_nccl_rollout_sync_is_valid_for_megatron_core():
+    config = make_config(
+        weight_sync_mode="nccl",
+        rollout_weight_sync_mode="nccl",
+        rollout_weight_sync_control_dir="/tmp/libra-rollout-sync",
+    )
+
+    assert config.weight_sync_mode == "nccl"
+    assert config.rollout_weight_sync_mode == "nccl"
+
+
+def test_direct_nccl_rollout_sync_rejects_serial_reload():
+    with pytest.raises(ValueError, match="parallel strategy"):
+        make_config(
+            weight_sync_mode="nccl",
+            rollout_weight_sync_mode="nccl",
+            rollout_weight_reload_strategy="serial",
+        )
+
+
+def test_direct_nccl_rollout_sync_rejects_disk_transport():
+    with pytest.raises(ValueError, match="weight_sync_mode='nccl'"):
+        make_config(
+            weight_sync_mode="disk",
+            rollout_weight_sync_mode="nccl",
+        )

--- a/tests/test_nccl_weight_sync.py
+++ b/tests/test_nccl_weight_sync.py
@@ -66,6 +66,28 @@ def test_nccl_stream_preserves_metadata_and_end_marker(monkeypatch):
     assert tensors == []
 
 
+def test_send_weights_can_keep_transport_alive(monkeypatch):
+    metadata = []
+    tensors = []
+    communicator = FakeCommunicator(0, metadata, tensors)
+    monkeypatch.setattr(nccl_weight_sync, "_communicator", lambda _spec: communicator)
+    monkeypatch.setattr(torch.Tensor, "to", lambda self, **_kwargs: self)
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda *_args, **_kwargs: SimpleNamespace(synchronize=lambda: None),
+    )
+    keepalive = []
+
+    nccl_weight_sync.send_weights(
+        [("weight", torch.ones(2, dtype=torch.float32))],
+        NcclReloadSpec("127.0.0.1", 29620, 2, 0, "cuda:0"),
+        keepalive=keepalive,
+    )
+
+    assert keepalive == [communicator]
+
+
 def test_nccl_dtype_rejects_unknown_values():
     try:
         nccl_weight_sync._dtype_from_name("not_a_dtype")

--- a/tests/test_nccl_weight_sync.py
+++ b/tests/test_nccl_weight_sync.py
@@ -129,3 +129,37 @@ def test_communicator_retains_vllm_constructor_warmup_output(monkeypatch):
     )
 
     assert communicator._constructor_warmup_output is None
+
+
+def test_communicator_is_cached_by_transport_identity(monkeypatch):
+    class FakePyNcclCommunicator:
+        init_count = 0
+
+        def __init__(self, group, device):
+            type(self).init_count += 1
+            self.group = group
+            self.device = device
+            self.all_reduce("warmup")
+
+        def all_reduce(self, _tensor, op=None, stream=None):
+            return object()
+
+    pynccl_module = ModuleType(
+        "vllm.distributed.device_communicators.pynccl"
+    )
+    pynccl_module.PyNcclCommunicator = FakePyNcclCommunicator
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.distributed.device_communicators.pynccl",
+        pynccl_module,
+    )
+    monkeypatch.setattr(nccl_weight_sync, "_group", lambda _spec: object())
+    nccl_weight_sync.clear_communicator_cache()
+    spec = NcclReloadSpec("127.0.0.1", 29620, 3, 0, "cuda:0")
+
+    first = nccl_weight_sync._communicator(spec)
+    second = nccl_weight_sync._communicator(spec)
+
+    assert first is second
+    assert first.__class__.init_count == 1
+    nccl_weight_sync.clear_communicator_cache()

--- a/tests/test_nccl_weight_sync.py
+++ b/tests/test_nccl_weight_sync.py
@@ -1,0 +1,109 @@
+import sys
+from types import SimpleNamespace
+from types import ModuleType
+
+import torch
+
+from RL_Framework.infra.sync import nccl_weight_sync
+from RL_Framework.infra.sync.nccl_weight_sync import NcclReloadSpec
+
+
+class FakeGroup:
+    def __init__(self, rank, metadata):
+        self.rank = rank
+        self.metadata = metadata
+
+    def broadcast_obj(self, value, src):
+        assert src == 0
+        if self.rank == 0:
+            self.metadata.append(value)
+            return value
+        return self.metadata.pop(0)
+
+
+class FakeCommunicator:
+    def __init__(self, rank, metadata, tensors):
+        self.rank = rank
+        self.group = FakeGroup(rank, metadata)
+        self.tensors = tensors
+
+    def broadcast(self, tensor, src):
+        assert src == 0
+        if self.rank == 0:
+            self.tensors.append(tensor.clone())
+        else:
+            tensor.copy_(self.tensors.pop(0))
+
+
+def test_nccl_stream_preserves_metadata_and_end_marker(monkeypatch):
+    metadata = []
+    tensors = []
+    monkeypatch.setattr(
+        nccl_weight_sync,
+        "_communicator",
+        lambda spec: FakeCommunicator(spec.rank, metadata, tensors),
+    )
+    monkeypatch.setattr(torch.Tensor, "to", lambda self, **_kwargs: self)
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda *_args, **_kwargs: SimpleNamespace(synchronize=lambda: None),
+    )
+    sender = NcclReloadSpec("127.0.0.1", 29620, 2, 0, "cuda:0")
+    receiver = NcclReloadSpec("127.0.0.1", 29620, 2, 1, "cpu")
+    source = [
+        ("model.embed_tokens.weight", torch.arange(6, dtype=torch.bfloat16).reshape(2, 3)),
+        ("lm_head.weight", torch.ones(1, dtype=torch.float32)),
+    ]
+
+    assert nccl_weight_sync.send_weights(source, sender) == 2
+    received = list(nccl_weight_sync.receive_weights(receiver))
+
+    assert [name for name, _tensor in received] == [name for name, _tensor in source]
+    assert torch.equal(received[0][1], source[0][1])
+    assert received[0][1].dtype == torch.bfloat16
+    assert metadata == []
+    assert tensors == []
+
+
+def test_nccl_dtype_rejects_unknown_values():
+    try:
+        nccl_weight_sync._dtype_from_name("not_a_dtype")
+    except ValueError as exc:
+        assert "Unsupported NCCL weight dtype" in str(exc)
+    else:
+        raise AssertionError("unknown dtype must be rejected")
+
+
+def test_communicator_retains_vllm_constructor_warmup_output(monkeypatch):
+    warmup_output = object()
+
+    class FakePyNcclCommunicator:
+        def __init__(self, group, device):
+            self.group = group
+            self.device = device
+            result = self.all_reduce("warmup")
+            assert result is warmup_output
+            assert self._constructor_warmup_output is warmup_output
+
+        def all_reduce(self, _tensor, op=None, stream=None):
+            assert op is None
+            assert stream is None
+            return warmup_output
+
+    pynccl_module = ModuleType(
+        "vllm.distributed.device_communicators.pynccl"
+    )
+    pynccl_module.PyNcclCommunicator = FakePyNcclCommunicator
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.distributed.device_communicators.pynccl",
+        pynccl_module,
+    )
+    monkeypatch.setattr(nccl_weight_sync, "_group", lambda _spec: object())
+
+    communicator = nccl_weight_sync._communicator(
+        NcclReloadSpec("127.0.0.1", 29620, 3, 0, "cuda:0")
+    )
+
+    assert communicator._constructor_warmup_output is None

--- a/tests/test_vllm_hot_reload.py
+++ b/tests/test_vllm_hot_reload.py
@@ -108,3 +108,48 @@ def test_reload_inplace_posts_checkpoint_to_reload_endpoint(monkeypatch):
         "timeout": 40.0,
     }
     assert result == {"workers": [{"rank": 0}]}
+
+
+def test_reload_nccl_posts_transport_metadata(monkeypatch):
+    script = Path(__file__).parents[1] / "scripts" / "restartable_vllm_server.py"
+    spec = importlib.util.spec_from_file_location("restartable_vllm_server_nccl", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    captured = {}
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"workers": [{"nccl_rank": 1}]}'
+
+    def urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", urlopen)
+    payload = {
+        "host": "10.0.0.1",
+        "port": 29621,
+        "world_size": 3,
+        "rank_offset": 0,
+        "timeout_seconds": 30.0,
+    }
+
+    result = module.reload_nccl("http://127.0.0.1:8000/health", payload, 30.0)
+
+    assert captured == {
+        "url": "http://127.0.0.1:8000/reload_weights_nccl",
+        "payload": payload,
+        "timeout": 40.0,
+    }
+    assert result["workers"][0]["nccl_rank"] == 1

--- a/trainer/async_rl_trainer.py
+++ b/trainer/async_rl_trainer.py
@@ -1119,6 +1119,7 @@ class AsyncRLTrainer:
         weights = self.train_engine.stream_rollout_weights()
         started = time.perf_counter()
         transferred_bytes = 0
+        transport_keepalive: list[object] = []
         if self.is_main_process:
             def record_tensor(_name: str, size_bytes: int) -> None:
                 nonlocal transferred_bytes
@@ -1141,6 +1142,7 @@ class AsyncRLTrainer:
                     ),
                 ),
                 on_tensor=record_tensor,
+                keepalive=transport_keepalive,
             )
         else:
             # The export itself contains Megatron TP/EP collectives.
@@ -1182,6 +1184,7 @@ class AsyncRLTrainer:
                 f"seconds={time.perf_counter() - started:.3f}",
                 flush=True,
             )
+            transport_keepalive.clear()
         if dist.is_initialized():
             dist.barrier()
         self._record_weight_sync_phase("sync_complete")

--- a/trainer/async_rl_trainer.py
+++ b/trainer/async_rl_trainer.py
@@ -1013,6 +1013,9 @@ class AsyncRLTrainer:
 
     def _sync_weights(self, target_version: int):
         """Sync weights."""
+        if self.config.weight_sync_mode == "nccl":
+            self._sync_weights_nccl(target_version)
+            return
         if self.config.weight_sync_mode == "disk":
             if self.is_main_process:
                 print(f"Synchronizing weights (step={self.global_step})")
@@ -1036,9 +1039,152 @@ class AsyncRLTrainer:
                 if dist.is_initialized():
                     dist.barrier()
 
-        elif self.config.weight_sync_mode == "nccl":
-            if self.is_main_process:
-                print("WARNING: NCCL weight synchronization requires additional distributed setup")
+
+    def _nccl_rollout_topology(self) -> tuple[int, dict[str, int]]:
+        """Return NCCL world size and per-instance rank offsets."""
+        if self._use_heterogeneous:
+            entries = [
+                (str(cfg["instance_id"]), int(cfg.get("tp_degree", 1)))
+                for cfg in self.rollout_engine.instance_configs
+            ]
+        else:
+            tp = int(getattr(self.config, "vllm_tp_size", 1) or 1)
+            entries = [
+                (f"instance_{index}", tp)
+                for index in range(self.rollout_engine.num_instances)
+            ]
+        offsets: dict[str, int] = {}
+        next_rank = 0
+        for instance_id, tp_degree in entries:
+            offsets[instance_id] = next_rank
+            next_rank += max(1, tp_degree)
+        return 1 + next_rank, offsets
+
+    def _sync_weights_nccl(self, target_version: int) -> None:
+        """Stream Megatron Bridge tensors directly to all rollout workers."""
+        if str(getattr(self.train_engine, "train_backend", "")) != "megatron_core":
+            raise ValueError("Direct NCCL rollout sync requires train_backend=megatron_core")
+        control_dir_value = str(
+            getattr(self.config, "rollout_weight_sync_control_dir", "") or ""
+        )
+        if not control_dir_value:
+            raise ValueError("NCCL weight synchronization requires rollout_weight_sync_control_dir")
+        control_dir = Path(control_dir_value).resolve()
+        if self.is_main_process:
+            control_dir.mkdir(parents=True, exist_ok=True)
+
+        import socket
+
+        host = (
+            str(getattr(self.config, "rollout_nccl_host", "") or "")
+            or os.environ.get("MASTER_ADDR", "")
+            or socket.gethostbyname(socket.gethostname())
+        )
+        port = int(getattr(self.config, "rollout_nccl_port", 29620)) + (
+            int(target_version) % 1000
+        )
+        world_size, offsets = self._nccl_rollout_topology()
+        request = {
+            "mode": "nccl",
+            "version": int(target_version),
+            "nccl_host": host,
+            "nccl_port": port,
+            "nccl_world_size": world_size,
+            "nccl_rank_offsets": offsets,
+            "nccl_chunk_bytes": int(
+                getattr(self.config, "rollout_nccl_chunk_mb", 256)
+            )
+            * 1024
+            * 1024,
+            "reload_strategy": str(
+                getattr(self.config, "rollout_weight_reload_strategy", "parallel")
+            ),
+            "created_at": time.time(),
+        }
+        if self.is_main_process:
+            for instance_id in offsets:
+                (control_dir / f"ack_{instance_id}_{target_version}.json").unlink(
+                    missing_ok=True
+                )
+                (control_dir / f"error_{instance_id}_{target_version}.json").unlink(
+                    missing_ok=True
+                )
+            self._write_json_atomic(control_dir / "reload_request.json", request)
+
+        from RL_Framework.infra.sync.nccl_weight_sync import (
+            NcclReloadSpec,
+            send_weights,
+        )
+
+        weights = self.train_engine.stream_rollout_weights()
+        started = time.perf_counter()
+        transferred_bytes = 0
+        if self.is_main_process:
+            def record_tensor(_name: str, size_bytes: int) -> None:
+                nonlocal transferred_bytes
+                transferred_bytes += size_bytes
+
+            send_weights(
+                weights,
+                NcclReloadSpec(
+                    host=host,
+                    port=port,
+                    world_size=world_size,
+                    rank=0,
+                    device=torch.cuda.current_device(),
+                    timeout_s=float(
+                        getattr(self.config, "rollout_weight_sync_timeout_s", 1200.0)
+                    ),
+                    chunk_bytes=request["nccl_chunk_bytes"],
+                    rate_limit_gbps=float(
+                        getattr(self.config, "rollout_nccl_rate_limit_gbps", 0.0)
+                    ),
+                ),
+                on_tensor=record_tensor,
+            )
+        else:
+            # The export itself contains Megatron TP/EP collectives.
+            for _name, tensor in weights:
+                del tensor
+
+        if self.is_main_process:
+            timeout = float(getattr(self.config, "rollout_weight_sync_timeout_s", 1200.0))
+            deadline = time.monotonic() + timeout
+            pending = set(offsets)
+            while pending and time.monotonic() < deadline:
+                failures = {
+                    instance_id: (control_dir / f"error_{instance_id}_{target_version}.json").read_text(
+                        encoding="utf-8"
+                    )
+                    for instance_id in pending
+                    if (control_dir / f"error_{instance_id}_{target_version}.json").exists()
+                }
+                if failures:
+                    raise RuntimeError(f"vLLM NCCL reload failed: {failures}")
+                pending = {
+                    instance_id
+                    for instance_id in pending
+                    if not (control_dir / f"ack_{instance_id}_{target_version}.json").exists()
+                }
+                if pending:
+                    time.sleep(1.0)
+            if pending:
+                raise TimeoutError(f"Timed out waiting for NCCL reload: {sorted(pending)}")
+            self._record_rollout_weight_version(
+                target_version=target_version,
+                checkpoint_path="",
+                instance_ids=list(offsets),
+            )
+            print(
+                f"Direct NCCL rollout refresh complete: version={target_version}, "
+                f"world_size={world_size}, model_bytes={transferred_bytes}, "
+                f"fanout_bytes={transferred_bytes * (world_size - 1)}, "
+                f"seconds={time.perf_counter() - started:.3f}",
+                flush=True,
+            )
+        if dist.is_initialized():
+            dist.barrier()
+        self._record_weight_sync_phase("sync_complete")
 
     @contextmanager
     def _rollout_export_only_context(self, mode: str):

--- a/trainer/async_rl_trainer.py
+++ b/trainer/async_rl_trainer.py
@@ -1080,9 +1080,10 @@ class AsyncRLTrainer:
             or os.environ.get("MASTER_ADDR", "")
             or socket.gethostbyname(socket.gethostname())
         )
-        port = int(getattr(self.config, "rollout_nccl_port", 29620)) + (
-            int(target_version) % 1000
-        )
+        # Reuse one communicator across refreshes. The per-rank broadcast
+        # counters provide generation ordering; changing the port here would
+        # pay NCCL/TCPStore bootstrap on every training version.
+        port = int(getattr(self.config, "rollout_nccl_port", 29620))
         world_size, offsets = self._nccl_rollout_topology()
         request = {
             "mode": "nccl",

--- a/vllm_hot_reload.py
+++ b/vllm_hot_reload.py
@@ -56,3 +56,40 @@ class InplaceReloadWorkerExtension:
             "finished_at": finished_at,
             "load_seconds": time.perf_counter() - started,
         }
+
+    def reload_weights_nccl(
+        self,
+        host: str,
+        port: int,
+        world_size: int,
+        rank_offset: int,
+        timeout_seconds: float = 1200.0,
+        chunk_bytes: int = 256 * 1024 * 1024,
+    ) -> dict[str, Any]:
+        """Load full HF-format weights from a Megatron NCCL broadcast."""
+        import torch
+
+        from RL_Framework.infra.sync.nccl_weight_sync import (
+            NcclReloadSpec,
+            receive_weights,
+        )
+
+        local_rank = int(getattr(self, "rank", 0))
+        spec = NcclReloadSpec(
+            host=str(host),
+            port=int(port),
+            world_size=int(world_size),
+            rank=1 + int(rank_offset) + local_rank,
+            device=torch.cuda.current_device(),
+            timeout_s=float(timeout_seconds),
+            chunk_bytes=int(chunk_bytes),
+        )
+        started = time.perf_counter()
+        loaded = self.model_runner.model.load_weights(receive_weights(spec))
+        torch.cuda.synchronize()
+        return {
+            "rank": local_rank,
+            "nccl_rank": spec.rank,
+            "loaded_parameters": len(loaded) if loaded is not None else 0,
+            "load_seconds": time.perf_counter() - started,
+        }


### PR DESCRIPTION
Implementation details:

1. Communicator is cached by (host, port, world_size, rank, device).
2. Rollout_nccl_port remains stable across different training steps.
3. TCPStore broadcast counter automatically distinguishes between consecutive refresh generations.
4. A new communicator is created when the process restarts or the topology changes.
5. Supports multiple rounds of hot-loading performance verification for the same process.